### PR TITLE
Colored letter support

### DIFF
--- a/src/main/java/net/logicsquad/nanocaptcha/image/renderer/AbstractWordRenderer.java
+++ b/src/main/java/net/logicsquad/nanocaptcha/image/renderer/AbstractWordRenderer.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import java.util.function.Supplier;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,7 +50,7 @@ public abstract class AbstractWordRenderer implements WordRenderer {
     /**
      * Default supplier of the {@link Color}
      */
-    protected static final ColorSupplier DEFAULT_COLOR_SUPPLIER = () -> DEFAULT_COLORS.get(RAND.nextInt(DEFAULT_COLORS.size()));
+    protected static final Supplier<Color> DEFAULT_COLOR_SUPPLIER = () -> DEFAULT_COLORS.get(RAND.nextInt(DEFAULT_COLORS.size()));
 
 	/**
 	 * Default fonts
@@ -101,7 +102,7 @@ public abstract class AbstractWordRenderer implements WordRenderer {
 	/**
 	 * Supplier of {@link Color}
 	 */
-	private final ColorSupplier wordColorSupplier;
+	private final Supplier<Color> wordColorSupplier;
 
 	/**
 	 * Constructor
@@ -119,7 +120,7 @@ public abstract class AbstractWordRenderer implements WordRenderer {
 	 * @param xOffset x-axis offset
 	 * @param yOffset y-axis offset
 	 */
-	protected AbstractWordRenderer(double xOffset, double yOffset, ColorSupplier wordColorSupplier) {
+	protected AbstractWordRenderer(double xOffset, double yOffset, Supplier<Color> wordColorSupplier) {
 		this.xOffset = xOffset;
 		this.yOffset = yOffset;
         this.wordColorSupplier = wordColorSupplier;
@@ -146,7 +147,7 @@ public abstract class AbstractWordRenderer implements WordRenderer {
         /**
          * Supplier of {@link Color}
          */
-        protected ColorSupplier wordColorSupplier;
+        protected Supplier<Color> wordColorSupplier;
 
 		/**
 		 * Constructor
@@ -232,30 +233,6 @@ public abstract class AbstractWordRenderer implements WordRenderer {
 
 	}
 
-	/**
-	 * The AbstractWordRenderer class's inner interface for supplying {@link Color} objects.
-	 * This interface allows for dynamic color provisioning within the rendering process of the AbstractWordRenderer.
-	 * It's designed to be implemented by clients who wish to control the color selection in rendering operations.
-	 * <p>
-	 * As an inner interface of AbstractWordRenderer, ColorSupplier is integral to defining custom color behavior
-	 * for various rendering tasks performed by instances of AbstractWordRenderer or its subclasses.
-	 * <p>
-	 * Example usage (as an inner interface):
-	 * <pre>
-	 *     AbstractWordRenderer.ColorSupplier supplier = () -> Color.RED; // Supplies a constant color
-	 * </pre>
-	 *
-	 * @see AbstractWordRenderer
-	 */
-	public interface ColorSupplier {
-		/**
-		 * Retrieves a {@link Color}.
-		 *
-		 * @return The color to be used next in the rendering process.
-		 */
-		Color get();
-	}
-
 
 	/**
 	 * Returns x-axis offset.
@@ -280,7 +257,7 @@ public abstract class AbstractWordRenderer implements WordRenderer {
 	 *
 	 * @return word color supplier
 	 */
-	protected ColorSupplier wordColorSupplier() {
+	protected Supplier<Color> wordColorSupplier() {
 		return wordColorSupplier;
 	}
 

--- a/src/main/java/net/logicsquad/nanocaptcha/image/renderer/DefaultWordRenderer.java
+++ b/src/main/java/net/logicsquad/nanocaptcha/image/renderer/DefaultWordRenderer.java
@@ -19,11 +19,6 @@ import java.util.List;
  */
 public class DefaultWordRenderer extends AbstractWordRenderer {
 	/**
-	 * List of available {@link Color}s
-	 */
-	private final List<Color> colors = new ArrayList<>();
-
-	/**
 	 * List of available {@link Font}s
 	 */
 	private final List<Font> fonts = new ArrayList<>();
@@ -34,7 +29,7 @@ public class DefaultWordRenderer extends AbstractWordRenderer {
 	 * @deprecated use {@link Builder} instead
 	 */
 	public DefaultWordRenderer() {
-		this(X_OFFSET_DEFAULT, Y_OFFSET_DEFAULT);
+		this(X_OFFSET_DEFAULT, Y_OFFSET_DEFAULT, DEFAULT_COLOR_SUPPLIER);
 		return;
 	}
 
@@ -45,23 +40,9 @@ public class DefaultWordRenderer extends AbstractWordRenderer {
 	 * @param yOffset y-axis offset
 	 * @since 1.4
 	 */
-	private DefaultWordRenderer(double xOffset, double yOffset) {
-		super(xOffset, yOffset);
-		this.colors.addAll(DEFAULT_COLORS);
+	private DefaultWordRenderer(double xOffset, double yOffset, ColorSupplier wordColorSupplier) {
+		super(xOffset, yOffset, wordColorSupplier);
 		this.fonts.addAll(DEFAULT_FONTS);
-		return;
-	}
-
-	/**
-	 * Constructor taking a list of {@link Color}s and {@link Font}s to choose from.
-	 *
-	 * @param colors {@link Color}s
-	 * @param fonts  {@link Font}s
-	 * @deprecated use {@link Builder} instead
-	 */
-	public DefaultWordRenderer(List<Color> colors, List<Font> fonts) {
-		this.colors.addAll(colors);
-		this.fonts.addAll(fonts);
 		return;
 	}
 
@@ -81,7 +62,7 @@ public class DefaultWordRenderer extends AbstractWordRenderer {
 		for (char c : word.toCharArray()) {
 			chars[0] = c;
 
-			g.setColor(nextColor());
+			g.setColor(wordColorSupplier().get());
 			Font font = nextFont();
 			g.setFont(font);
 			GlyphVector gv = font.createGlyphVector(frc, chars);
@@ -89,20 +70,6 @@ public class DefaultWordRenderer extends AbstractWordRenderer {
 
 			int width = (int) gv.getVisualBounds().getWidth();
 			xBaseline = xBaseline + width;
-		}
-	}
-
-	/**
-	 * Returns a random {@link Color} from the list.
-	 * 
-	 * @return random {@link Color}
-	 * @since 1.1
-	 */
-	private Color nextColor() {
-		if (colors.size() == 1) {
-			return colors.get(0);
-		} else {
-			return colors.get(RAND.nextInt(colors.size()));
 		}
 	}
 
@@ -128,7 +95,7 @@ public class DefaultWordRenderer extends AbstractWordRenderer {
 	public static class Builder extends AbstractWordRenderer.Builder {
 		@Override
 		public DefaultWordRenderer build() {
-			return new DefaultWordRenderer(xOffset, yOffset);
+			return new DefaultWordRenderer(xOffset, yOffset, wordColorSupplier);
 		}
 	}
 }

--- a/src/main/java/net/logicsquad/nanocaptcha/image/renderer/DefaultWordRenderer.java
+++ b/src/main/java/net/logicsquad/nanocaptcha/image/renderer/DefaultWordRenderer.java
@@ -9,6 +9,7 @@ import java.awt.font.GlyphVector;
 import java.awt.image.BufferedImage;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * Renders the content onto the image.
@@ -40,7 +41,7 @@ public class DefaultWordRenderer extends AbstractWordRenderer {
 	 * @param yOffset y-axis offset
 	 * @since 1.4
 	 */
-	private DefaultWordRenderer(double xOffset, double yOffset, ColorSupplier wordColorSupplier) {
+	private DefaultWordRenderer(double xOffset, double yOffset, Supplier<Color> wordColorSupplier) {
 		super(xOffset, yOffset, wordColorSupplier);
 		this.fonts.addAll(DEFAULT_FONTS);
 		return;

--- a/src/main/java/net/logicsquad/nanocaptcha/image/renderer/FastWordRenderer.java
+++ b/src/main/java/net/logicsquad/nanocaptcha/image/renderer/FastWordRenderer.java
@@ -79,11 +79,6 @@ public class FastWordRenderer extends AbstractWordRenderer {
 	private static AtomicInteger fudgePointer = new AtomicInteger(0);
 
 	/**
-	 * Available {@link Color}
-	 */
-	private static final Color COLOR = Color.BLACK;
-
-	/**
 	 * Available {@link Font}s
 	 */
 	private static final Font[] FONTS = new Font[2];
@@ -107,7 +102,7 @@ public class FastWordRenderer extends AbstractWordRenderer {
 	 * @deprecated use {@link Builder} instead
 	 */
 	public FastWordRenderer() {
-		this(X_OFFSET_DEFAULT, Y_OFFSET_DEFAULT);
+		this(X_OFFSET_DEFAULT, Y_OFFSET_DEFAULT, DEFAULT_COLOR_SUPPLIER);
 		return;
 	}
 
@@ -118,8 +113,8 @@ public class FastWordRenderer extends AbstractWordRenderer {
 	 * @param yOffset y-axis offset
 	 * @since 1.4
 	 */
-	private FastWordRenderer(double xOffset, double yOffset) {
-		super(xOffset, yOffset);
+	private FastWordRenderer(double xOffset, double yOffset, ColorSupplier wordColorSupplier) {
+		super(xOffset, yOffset, wordColorSupplier);
 		return;
 	}
 
@@ -131,7 +126,7 @@ public class FastWordRenderer extends AbstractWordRenderer {
 		char[] chars = new char[1];
 		for (char c : word.toCharArray()) {
 			chars[0] = c;
-			g.setColor(COLOR);
+			g.setColor(wordColorSupplier().get());
 			g.setFont(nextFont());
 			int xFudge = nextFudge();
 			int yFudge = nextFudge();
@@ -170,7 +165,7 @@ public class FastWordRenderer extends AbstractWordRenderer {
 	public static class Builder extends AbstractWordRenderer.Builder {
 		@Override
 		public FastWordRenderer build() {
-			return new FastWordRenderer(xOffset, yOffset);
+			return new FastWordRenderer(xOffset, yOffset, wordColorSupplier);
 		}
 	}
 }

--- a/src/main/java/net/logicsquad/nanocaptcha/image/renderer/FastWordRenderer.java
+++ b/src/main/java/net/logicsquad/nanocaptcha/image/renderer/FastWordRenderer.java
@@ -1,9 +1,9 @@
 package net.logicsquad.nanocaptcha.image.renderer;
 
-import java.awt.Font;
-import java.awt.Graphics2D;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 /**
  * <p>
@@ -111,7 +111,7 @@ public class FastWordRenderer extends AbstractWordRenderer {
 	 * @param yOffset y-axis offset
 	 * @since 1.4
 	 */
-	private FastWordRenderer(double xOffset, double yOffset, ColorSupplier wordColorSupplier) {
+	private FastWordRenderer(double xOffset, double yOffset, Supplier<Color> wordColorSupplier) {
 		super(xOffset, yOffset, wordColorSupplier);
 		return;
 	}

--- a/src/main/java/net/logicsquad/nanocaptcha/image/renderer/FastWordRenderer.java
+++ b/src/main/java/net/logicsquad/nanocaptcha/image/renderer/FastWordRenderer.java
@@ -1,6 +1,5 @@
 package net.logicsquad.nanocaptcha.image.renderer;
 
-import java.awt.Color;
 import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
@@ -14,7 +13,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * </p>
  * 
  * <ul>
- * <li>{@link Color} choices are limited: text is rendered in black.</li>
  * <li>{@link Font} choices are limited: renders with "Courier Prime" and "Public Sans".</li>
  * <li>Rendered text is <em>not</em> anti-aliased.</li>
  * <li>{@link DefaultWordRenderer} measures the size of each glyph it renders to calculate horizontal spacing. This class uses fixed


### PR DESCRIPTION
## Pull Request Etiquette

- [ ] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [X] Internal code
- [X] API (affecting end-user code)
- [ ] Other: _

Closes Issue: #16 

## Description

This pull request adds support for colored letters in AbstractWordRenderer. 

**Breaking changes**
The deprecated `DefaultWordRenderer(List<Color>, List<Font>)` has been removed due to incompatibility with implementation.

**Usage of `ColorSupplier` instead of `java.util.function.Supplier<Color>`**
To achieve this, we have implemented the interface ColorSupplier instead of using Supplier<Color>. The reason for avoiding `java.util.function.*` is due to its incompatibility with older Android versions (*idk if it does matter*). Additionally, the library does not utilize `java.util.function.*`, which is why a custom interface was used instead of the built-in interface.

**Added**
The following methods have been added to `AbstractWordRenderer.Builder`: 
  - `randomColor(Color, Color...)` - to generate a list of random colors, with the first color being required and any additional colors being optional.
  - `randomColor(List<Color>)` is the same as above, but uses a List.
  - `color(Color)` is a static color and is not random. 
  
**Current state**
The changes have not been tested.
It may be necessary to add tests to ensure it functions as expected.