### PR TITLE
Add GaussianNoiseProducer and SaltAndPepperNoiseProducer

### DIFF
--- a/src/main/java/net/logicsquad/nanocaptcha/image/noise/SaltAndPepperNoise.java
+++ b/src/main/java/net/logicsquad/nanocaptcha/image/noise/SaltAndPepperNoise.java
@@ -1,0 +1,83 @@
+package net.logicsquad.nanocaptcha.image.noise;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.util.Random;
+
+/**
+ * Applies salt and pepper noise to an image. This noise type randomly changes
+ * some of the pixels to black or white, creating a 'salt and pepper' effect.
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Salt-and-pepper_noise">Salt and pepper on Wikipedia</>
+ * @since 2.0
+ */
+public class SaltAndPepperNoise implements NoiseProducer {
+
+    /**
+     * Random number generator.
+     */
+    private static final Random RAND = new Random();
+
+    /**
+     * Default noise density.
+     */
+    private static final double DEFAULT_NOISE_DENSITY = 0.15;
+
+    /**
+     * RGB value of the "pepper".
+     */
+    private static final int PEPPER = Color.BLACK.getRGB();
+
+    /**
+     * RGB value of the "salt".
+     */
+    private static final int SALT = Color.WHITE.getRGB();
+
+    /**
+     * Noise density.
+     */
+    private final double noiseDensity;
+
+    /**
+     * Constructor using default standard deviation and mean.
+     */
+    public SaltAndPepperNoise() {
+        this(DEFAULT_NOISE_DENSITY);
+        return;
+    }
+
+    /**
+     * Constructor for salt and pepper noise producer.
+     *
+     * @param noiseDensity The density of the noise to be applied (0 to 1 range).
+     * @throws IllegalArgumentException when the noise density is not in the range of 0 to 1.
+     */
+    public SaltAndPepperNoise(double noiseDensity) {
+        if (noiseDensity < 0 || noiseDensity > 1) {
+            throw new IllegalArgumentException("Noise density must be between 0 and 1.");
+        }
+        this.noiseDensity = noiseDensity;
+        return;
+    }
+
+    /**
+     * Applies salt and pepper noise to the given image.
+     *
+     * @param image The BufferedImage to apply noise to
+     */
+    @Override
+    public void makeNoise(BufferedImage image) {
+        int width = image.getWidth();
+        int height = image.getHeight();
+
+        for (int x = 0; x < width; x++) {
+            for (int y = 0; y < height; y++) {
+                if (RAND.nextDouble() < noiseDensity) {
+                    int color = RAND.nextBoolean() ? PEPPER : SALT;
+                    image.setRGB(x, y, color);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/net/logicsquad/nanocaptcha/image/noise/SaltAndPepperNoiseProducer.java
+++ b/src/main/java/net/logicsquad/nanocaptcha/image/noise/SaltAndPepperNoiseProducer.java
@@ -11,7 +11,7 @@ import java.util.Random;
  * @see <a href="https://en.wikipedia.org/wiki/Salt-and-pepper_noise">Salt and pepper on Wikipedia</>
  * @since 2.0
  */
-public class SaltAndPepperNoise implements NoiseProducer {
+public class SaltAndPepperNoiseProducer implements NoiseProducer {
 
     /**
      * Random number generator.
@@ -41,7 +41,7 @@ public class SaltAndPepperNoise implements NoiseProducer {
     /**
      * Constructor using default standard deviation and mean.
      */
-    public SaltAndPepperNoise() {
+    public SaltAndPepperNoiseProducer() {
         this(DEFAULT_NOISE_DENSITY);
         return;
     }
@@ -52,7 +52,7 @@ public class SaltAndPepperNoise implements NoiseProducer {
      * @param noiseDensity The density of the noise to be applied (0 to 1 range).
      * @throws IllegalArgumentException when the noise density is not in the range of 0 to 1.
      */
-    public SaltAndPepperNoise(double noiseDensity) {
+    public SaltAndPepperNoiseProducer(double noiseDensity) {
         if (noiseDensity < 0 || noiseDensity > 1) {
             throw new IllegalArgumentException("Noise density must be between 0 and 1.");
         }


### PR DESCRIPTION
## Pull Request Etiquette

- [ ] I have checked the PRs for upcoming features/bug fixes.

### Changes

- [X] Internal code
- [X] API (affecting end-user code)
- [ ] Other: _

Closes Issue: #17 

## Description

This pull request adds Gaussian noise and Salt & Pepper noise features to the API.

## Image Output:
1. **Gaussian noise (standard deviation = 20, mean = 0)**
<details>
<summary>Image output (with code snippet)</summary>

```java
ImageCaptcha captcha = new ImageCaptcha.Builder(512, 512) // 100, 256, 512
                .addBackground(new FlatColorBackgroundProducer(Color.WHITE))
                .addContent()
                .addNoise(new GaussianNoiseProducer(20, 0))
                .build();
Path imagePath = Paths.get("captcha.png");
ImageIO.write(captcha.getImage(), "png", Files.newOutputStream(imagePath));
```

![gaussian-noise-512](https://github.com/logicsquad/nanocaptcha/assets/85439143/864cbda1-ec4d-4d63-ad64-8cf722841841)
![gaussian-noise-256](https://github.com/logicsquad/nanocaptcha/assets/85439143/34c555ce-5655-4e6f-92f4-f3125767b8b9)
![gaussian-noise-100](https://github.com/logicsquad/nanocaptcha/assets/85439143/52a50686-2061-4ad6-8a95-ca3fd74fab0a)

</details>

---

2. **Salt & Pepper noise (noise density = 0.15)**
<details>
<summary>Image output (with code snippet)</summary>

```java
ImageCaptcha captcha = new ImageCaptcha.Builder(512, 512) // 100, 256, 512
                .addBackground(new FlatColorBackgroundProducer(Color.WHITE))
                .addContent()
                .addNoise(new SaltAndPepperNoise(0.15))
                .build();
Path imagePath = Paths.get("captcha.png");
ImageIO.write(captcha.getImage(), "png", Files.newOutputStream(imagePath));
```

![salt-and-pepper-512](https://github.com/logicsquad/nanocaptcha/assets/85439143/f7b60195-3762-49ac-870f-d13951f2a5bd)
![salt-and-pepper-256](https://github.com/logicsquad/nanocaptcha/assets/85439143/a99356c1-e65e-43b8-82de-20bf9a7b3a1d)
![salt-and-pepper-100](https://github.com/logicsquad/nanocaptcha/assets/85439143/8c4214e7-73bc-43e8-8ad1-92bc455638be)


</details>

## Added
- `GaussianNoiseProducer` generates Gaussian noise with two parameters: *mean* and *standard deviation*. The standard deviation is responsible for adding noise to the image, while the mean adjusts the brightness.
- `SaltAndPepperNoiseProducer` generates Salt&Pepper noise in an image using a single parameter 'noise density'. The noise density parameter controls the number of dots in the image.